### PR TITLE
Feat/edit post

### DIFF
--- a/src/components/Post/elements/PostBox.js
+++ b/src/components/Post/elements/PostBox.js
@@ -19,20 +19,19 @@ export default function PostBox() {
     const [isEditing, setIsEditing] = useState(false);
     const inputRef = useRef(null);
 
-    function cancelDeletion() {
+    function cancelEditing() {
         setIsEditing(!isEditing);
-        setEditedMsg(text, id, login.token);
+        setEditedMsg(text);
     }
 
     function editPost() {
         setIsDataBeingEvaluated(true);
-        inputRef.current.blur();
-        publishEditedPost(editedMsg, id, login.token, setIsDataBeingEvaluated, setIsEditing, cancelDeletion);
+        publishEditedPost(editedMsg, id, login.token, setIsDataBeingEvaluated, setIsEditing, cancelEditing);
     }
 
     function analyzeRequest(e) {
         if(e.keyCode === 27) {
-            cancelDeletion()
+            cancelEditing()
         }
         if(e.keyCode === 13) {
             editPost()
@@ -43,11 +42,11 @@ export default function PostBox() {
         if(isEditing) {
             inputRef.current.focus();
         }
-    }, [isEditing]);
+    }, [isEditing, isDataBeingEvaluated]);
     
     return (
         <Wrapper>
-            <PostHeader setIsEditing={setIsEditing} isEditing={isEditing} cancelDeletion={cancelDeletion}/>
+            <PostHeader setIsEditing={setIsEditing} isEditing={isEditing} cancelEditing={cancelEditing}/>
             {isEditing ?
             <EditInput 
             disabled={isDataBeingEvaluated} 

--- a/src/components/Post/elements/PostBox.js
+++ b/src/components/Post/elements/PostBox.js
@@ -5,24 +5,32 @@ import PostContext from "../../../contexts/PostContext";
 import { TextWithHighlightedHashtags } from "../../../utils/TextAdjustmentsUtils";
 
 import styled from "styled-components";
-import { useContext } from "react";
+import { useContext, useState } from "react";
 
 export default function PostBox() {
 
     const { text } = useContext(PostContext);
+    const [isEditing, setIsEditing] = useState(false);
     
     return (
         <Wrapper>
-            <PostHeader />
+            <PostHeader setIsEditing={setIsEditing}/>
+            {isEditing ?<EditInput value={text}/> :
             <TextWithHighlightedHashtags 
                 text = {text}
                 MainStyledComponent = {Description}
                 HashtagStyledComponent = {Hashtag}
-            />
+            />}
             <LinkBox />
         </Wrapper>
     );
 }
+
+const EditInput = styled.input`
+    font-size: 18px;
+    line-height: 25px;
+    margin: 8px 0px;
+`;
 
 const Wrapper = styled.div`
     width: 100%;

--- a/src/components/Post/elements/PostBox.js
+++ b/src/components/Post/elements/PostBox.js
@@ -5,10 +5,10 @@ import PostContext from "../../../contexts/PostContext";
 import DataEvaluationContext from "../../../contexts/DataEvaluationContext";
 import UserContext from "../../../contexts/UserContext";
 import { TextWithHighlightedHashtags } from "../../../utils/TextAdjustmentsUtils";
+import { cancelEditing, analyzeRequest } from "../../../utils/PostsUtils";
 
 import styled from "styled-components";
 import { useContext, useState, useRef, useEffect } from "react";
-import { publishEditedPost } from "../../../service/service";
 
 export default function PostBox() {
 
@@ -19,25 +19,6 @@ export default function PostBox() {
     const [isEditing, setIsEditing] = useState(false);
     const inputRef = useRef(null);
 
-    function cancelEditing() {
-        setIsEditing(!isEditing);
-        setEditedMsg(text);
-    }
-
-    function editPost() {
-        setIsDataBeingEvaluated(true);
-        publishEditedPost(editedMsg, id, login.token, setIsDataBeingEvaluated, setIsEditing, cancelEditing);
-    }
-
-    function analyzeRequest(e) {
-        if(e.keyCode === 27) {
-            cancelEditing()
-        }
-        if(e.keyCode === 13) {
-            editPost()
-        }
-    }
-
     useEffect(() => {
         if(isEditing) {
             inputRef.current.focus();
@@ -46,11 +27,11 @@ export default function PostBox() {
     
     return (
         <Wrapper>
-            <PostHeader setIsEditing={setIsEditing} isEditing={isEditing} cancelEditing={cancelEditing}/>
+            <PostHeader setIsEditing={setIsEditing} isEditing={isEditing} cancelEditing={cancelEditing} setEditedMsg={setEditedMsg}/>
             {isEditing ?
             <EditInput 
             disabled={isDataBeingEvaluated} 
-            onKeyUp={analyzeRequest} 
+            onKeyUp={(e) => analyzeRequest(e, editedMsg, id, login.token, setIsDataBeingEvaluated, setIsEditing, cancelEditing, isEditing, text, setEditedMsg)} 
             ref={inputRef} 
             value={editedMsg} 
             onChange={e => setEditedMsg(e.target.value)}

--- a/src/components/Post/elements/PostBox.js
+++ b/src/components/Post/elements/PostBox.js
@@ -49,7 +49,13 @@ export default function PostBox() {
         <Wrapper>
             <PostHeader setIsEditing={setIsEditing} isEditing={isEditing} cancelDeletion={cancelDeletion}/>
             {isEditing ?
-            <EditInput wrap="soft" isDataBeingEvaluated={isDataBeingEvaluated} onKeyUp={analyzeRequest} ref={inputRef} value={editedMsg} onChange={e => setEditedMsg(e.target.value)}/> 
+            <EditInput 
+            disabled={isDataBeingEvaluated} 
+            onKeyUp={analyzeRequest} 
+            ref={inputRef} 
+            value={editedMsg} 
+            onChange={e => setEditedMsg(e.target.value)}
+            /> 
             :
             <TextWithHighlightedHashtags 
                 text = {editedMsg}
@@ -70,7 +76,7 @@ const EditInput = styled.input`
     border: none;
     padding: 0 5px;
     background: ${({isDataBeingEvaluated}) => isDataBeingEvaluated ? `#c2c2c2` : `#FFFFFF`};
-    pointer-events: ${({isDataBeingEvaluated}) => isDataBeingEvaluated ? `none` : `initial`};
+    outline: none;
 `;
 
 const Wrapper = styled.div`

--- a/src/components/Post/elements/PostBox.js
+++ b/src/components/Post/elements/PostBox.js
@@ -2,22 +2,57 @@ import PostHeader from "./PostHeader";
 import LinkBox from "./LinkBox";
 
 import PostContext from "../../../contexts/PostContext";
+import DataEvaluationContext from "../../../contexts/DataEvaluationContext";
+import UserContext from "../../../contexts/UserContext";
 import { TextWithHighlightedHashtags } from "../../../utils/TextAdjustmentsUtils";
 
 import styled from "styled-components";
-import { useContext, useState } from "react";
+import { useContext, useState, useRef, useEffect } from "react";
+import { publishEditedPost } from "../../../service/service";
 
 export default function PostBox() {
 
-    const { text } = useContext(PostContext);
+    const {isDataBeingEvaluated, setIsDataBeingEvaluated} = useContext(DataEvaluationContext);
+    const { id, text } = useContext(PostContext);
+    const {login} = useContext(UserContext);
+    const [editedMsg, setEditedMsg] = useState(text);
     const [isEditing, setIsEditing] = useState(false);
+    const inputRef = useRef(null);
+
+    function cancelDeletion() {
+        setIsEditing(!isEditing);
+        setEditedMsg(text, id, login.token);
+    }
+
+    function editPost() {
+        setIsDataBeingEvaluated(true);
+        inputRef.current.blur();
+        publishEditedPost(editedMsg, id, login.token, setIsDataBeingEvaluated, setIsEditing, cancelDeletion);
+    }
+
+    function analyzeRequest(e) {
+        if(e.keyCode === 27) {
+            cancelDeletion()
+        }
+        if(e.keyCode === 13) {
+            editPost()
+        }
+    }
+
+    useEffect(() => {
+        if(isEditing) {
+            inputRef.current.focus();
+        }
+    }, [isEditing]);
     
     return (
         <Wrapper>
-            <PostHeader setIsEditing={setIsEditing}/>
-            {isEditing ?<EditInput value={text}/> :
+            <PostHeader setIsEditing={setIsEditing} isEditing={isEditing} cancelDeletion={cancelDeletion}/>
+            {isEditing ?
+            <EditInput wrap="soft" isDataBeingEvaluated={isDataBeingEvaluated} onKeyUp={analyzeRequest} ref={inputRef} value={editedMsg} onChange={e => setEditedMsg(e.target.value)}/> 
+            :
             <TextWithHighlightedHashtags 
-                text = {text}
+                text = {editedMsg}
                 MainStyledComponent = {Description}
                 HashtagStyledComponent = {Hashtag}
             />}
@@ -27,9 +62,15 @@ export default function PostBox() {
 }
 
 const EditInput = styled.input`
+    width: 100%;
     font-size: 18px;
     line-height: 25px;
     margin: 8px 0px;
+    border-radius: 5px;
+    border: none;
+    padding: 0 5px;
+    background: ${({isDataBeingEvaluated}) => isDataBeingEvaluated ? `#c2c2c2` : `#FFFFFF`};
+    pointer-events: ${({isDataBeingEvaluated}) => isDataBeingEvaluated ? `none` : `initial`};
 `;
 
 const Wrapper = styled.div`

--- a/src/components/Post/elements/PostHeader.js
+++ b/src/components/Post/elements/PostHeader.js
@@ -8,7 +8,7 @@ import { FaTrash } from "react-icons/fa";
 import { RiPencilFill } from "react-icons/ri";
 import { useContext, useState } from "react";
 
-export default function PostHeader({setIsEditing}) {
+export default function PostHeader({setIsEditing, isEditing, cancelDeletion}) {
     const { id, user } = useContext(PostContext);
     const {login} = useContext(UserContext);
     const [openModal, setOpenModal] = useState(false);
@@ -20,7 +20,7 @@ export default function PostHeader({setIsEditing}) {
             </Link>
             {(Number(login.user.id) === Number(user.id)) ? 
                 <>
-                    <IconButton right = {"25px"} onClick={() => setIsEditing(true)}>
+                    <IconButton right = {"25px"} onClick={() => isEditing ? cancelDeletion() : setIsEditing(!isEditing)}>
                         <RiPencilFill />
                     </IconButton>
                     <IconButton right = {"0px"} onClick={() => setOpenModal(true)}>

--- a/src/components/Post/elements/PostHeader.js
+++ b/src/components/Post/elements/PostHeader.js
@@ -1,5 +1,6 @@
 import PostContext from "../../../contexts/PostContext";
 import UserContext from "../../../contexts/UserContext";
+import DataEvaluationContext from "../../../contexts/DataEvaluationContext";
 import Modal from "../../Modal";
 
 import styled from "styled-components";
@@ -9,6 +10,7 @@ import { RiPencilFill } from "react-icons/ri";
 import { useContext, useState } from "react";
 
 export default function PostHeader({setIsEditing, isEditing, cancelDeletion}) {
+    const {isDataBeingEvaluated} = useContext(DataEvaluationContext)
     const { id, user } = useContext(PostContext);
     const {login} = useContext(UserContext);
     const [openModal, setOpenModal] = useState(false);
@@ -20,15 +22,15 @@ export default function PostHeader({setIsEditing, isEditing, cancelDeletion}) {
             </Link>
             {(Number(login.user.id) === Number(user.id)) ? 
                 <>
-                    <IconButton right = {"25px"} onClick={() => isEditing ? cancelDeletion() : setIsEditing(!isEditing)}>
+                    <IconButton right = {"25px"} onClick={() => isEditing ? cancelDeletion() : setIsEditing(!isEditing)} disabled={isDataBeingEvaluated}>
                         <RiPencilFill />
                     </IconButton>
-                    <IconButton right = {"0px"} onClick={() => setOpenModal(true)}>
+                    <IconButton right = {"0px"} onClick={() => setOpenModal(true)} disabled={isDataBeingEvaluated}>
                         <FaTrash />
                     </IconButton>
                 </>
             : ""}
-            {openModal&&<Modal openModal={openModal} setOpenModal={setOpenModal} id={id} token ={login.token}/>}
+            {openModal&&<Modal openModal={openModal} setOpenModal={setOpenModal} id={id} token ={login.token} />}
         </Wrapper>
     );
 }

--- a/src/components/Post/elements/PostHeader.js
+++ b/src/components/Post/elements/PostHeader.js
@@ -9,9 +9,9 @@ import { FaTrash } from "react-icons/fa";
 import { RiPencilFill } from "react-icons/ri";
 import { useContext, useState } from "react";
 
-export default function PostHeader({setIsEditing, isEditing, cancelEditing}) {
+export default function PostHeader({setIsEditing, isEditing, cancelEditing, setEditedMsg}) {
     const {isDataBeingEvaluated} = useContext(DataEvaluationContext)
-    const { id, user } = useContext(PostContext);
+    const { id, user, text } = useContext(PostContext);
     const {login} = useContext(UserContext);
     const [openModal, setOpenModal] = useState(false);
     const imageRoute = user.id === Number(login.user.id) ? "my-posts" : `/user/${user.id}`;
@@ -23,7 +23,7 @@ export default function PostHeader({setIsEditing, isEditing, cancelEditing}) {
             </Link>
             {(Number(login.user.id) === Number(user.id)) ? 
                 <>
-                    <IconButton right = {"25px"} onClick={() => isEditing ? cancelEditing() : setIsEditing(!isEditing)} disabled={isDataBeingEvaluated}>
+                    <IconButton right = {"25px"} onClick={() => isEditing ? cancelEditing(isEditing, text, setIsEditing, setEditedMsg) : setIsEditing(!isEditing)} disabled={isDataBeingEvaluated}>
                         <RiPencilFill />
                     </IconButton>
                     <IconButton right = {"0px"} onClick={() => setOpenModal(true)} disabled={isDataBeingEvaluated}>

--- a/src/components/Post/elements/PostHeader.js
+++ b/src/components/Post/elements/PostHeader.js
@@ -14,10 +14,11 @@ export default function PostHeader({setIsEditing, isEditing, cancelEditing}) {
     const { id, user } = useContext(PostContext);
     const {login} = useContext(UserContext);
     const [openModal, setOpenModal] = useState(false);
+    const imageRoute = user.id === Number(login.user.id) ? "my-posts" : `/user/${user.id}`;
 
     return (
         <Wrapper>
-            <Link to={`/user/${id}`}>
+            <Link to={imageRoute}>
                 {user.username}
             </Link>
             {(Number(login.user.id) === Number(user.id)) ? 

--- a/src/components/Post/elements/PostHeader.js
+++ b/src/components/Post/elements/PostHeader.js
@@ -9,7 +9,7 @@ import { FaTrash } from "react-icons/fa";
 import { RiPencilFill } from "react-icons/ri";
 import { useContext, useState } from "react";
 
-export default function PostHeader({setIsEditing, isEditing, cancelDeletion}) {
+export default function PostHeader({setIsEditing, isEditing, cancelEditing}) {
     const {isDataBeingEvaluated} = useContext(DataEvaluationContext)
     const { id, user } = useContext(PostContext);
     const {login} = useContext(UserContext);
@@ -22,7 +22,7 @@ export default function PostHeader({setIsEditing, isEditing, cancelDeletion}) {
             </Link>
             {(Number(login.user.id) === Number(user.id)) ? 
                 <>
-                    <IconButton right = {"25px"} onClick={() => isEditing ? cancelDeletion() : setIsEditing(!isEditing)} disabled={isDataBeingEvaluated}>
+                    <IconButton right = {"25px"} onClick={() => isEditing ? cancelEditing() : setIsEditing(!isEditing)} disabled={isDataBeingEvaluated}>
                         <RiPencilFill />
                     </IconButton>
                     <IconButton right = {"0px"} onClick={() => setOpenModal(true)} disabled={isDataBeingEvaluated}>

--- a/src/components/Post/elements/PostHeader.js
+++ b/src/components/Post/elements/PostHeader.js
@@ -8,7 +8,7 @@ import { FaTrash } from "react-icons/fa";
 import { RiPencilFill } from "react-icons/ri";
 import { useContext, useState } from "react";
 
-export default function PostHeader() {
+export default function PostHeader({setIsEditing}) {
     const { id, user } = useContext(PostContext);
     const {login} = useContext(UserContext);
     const [openModal, setOpenModal] = useState(false);
@@ -20,7 +20,7 @@ export default function PostHeader() {
             </Link>
             {(Number(login.user.id) === Number(user.id)) ? 
                 <>
-                    <IconButton right = {"25px"}>
+                    <IconButton right = {"25px"} onClick={() => setIsEditing(true)}>
                         <RiPencilFill />
                     </IconButton>
                     <IconButton right = {"0px"} onClick={() => setOpenModal(true)}>

--- a/src/components/Post/elements/PostHeader.js
+++ b/src/components/Post/elements/PostHeader.js
@@ -44,7 +44,7 @@ const Wrapper = styled.div`
     position: relative;
     & a {
             display: inline-block;
-            width: 85%;
+            max-width: 85%;
         }
     @media(max-width: 937px) {
         font-size: 17px;

--- a/src/service/service.js
+++ b/src/service/service.js
@@ -78,11 +78,11 @@ function deletePostFromServer(userToken, postId, setOpenModal, setIsDataBeingEva
     });
 }
 
-function publishEditedPost(editedMsg, postId, userToken, setIsDataBeingEvaluated, setIsEditing, cancelDeletion) {
+function publishEditedPost(editedMsg, postId, userToken, setIsDataBeingEvaluated, setIsEditing, cancelEditing) {
     const body = {
         text: editedMsg
     }
-    axios.put(`${URL}/posts/${postId}`, body, createConfig(userToken))
+    axios.put(`${URL}/postes/${postId}`, body, createConfig(userToken))
     .then(res => {
         setIsDataBeingEvaluated(false);
         setIsEditing(false);
@@ -90,8 +90,6 @@ function publishEditedPost(editedMsg, postId, userToken, setIsDataBeingEvaluated
     .catch(err => {
         alert("Houve um erro e seu post não pôde ser editado!");
         setIsDataBeingEvaluated(false);
-        setIsEditing(false);
-        cancelDeletion();
     });
 }
 

--- a/src/service/service.js
+++ b/src/service/service.js
@@ -68,7 +68,6 @@ function getUserPosts(userToken, userId, setUserPosts, setLoading) {
 function deletePostFromServer(userToken, postId, setOpenModal, setIsDataBeingEvaluated) {
     axios.delete(`${URL}/posts/${postId}`, createConfig(userToken))
     .then(res => {
-        console.log(res);
         setIsDataBeingEvaluated(false);
         setOpenModal(false);
     })
@@ -76,6 +75,23 @@ function deletePostFromServer(userToken, postId, setOpenModal, setIsDataBeingEva
         alert("Houve um erro e seu post não pôde ser excluído!");
         setIsDataBeingEvaluated(false);
         setOpenModal(false);
+    });
+}
+
+function publishEditedPost(editedMsg, postId, userToken, setIsDataBeingEvaluated, setIsEditing, cancelDeletion) {
+    const body = {
+        text: editedMsg
+    }
+    axios.put(`${URL}/posts/${postId}`, body, createConfig(userToken))
+    .then(res => {
+        setIsDataBeingEvaluated(false);
+        setIsEditing(false);
+    })
+    .catch(err => {
+        alert("Houve um erro e seu post não pôde ser editado!");
+        setIsDataBeingEvaluated(false);
+        setIsEditing(false);
+        cancelDeletion();
     });
 }
 
@@ -120,4 +136,5 @@ export {
     getTrendingTopics,
     getUserData,
     deletePostFromServer,
+    publishEditedPost,
 };

--- a/src/service/service.js
+++ b/src/service/service.js
@@ -82,7 +82,7 @@ function publishEditedPost(editedMsg, postId, userToken, setIsDataBeingEvaluated
     const body = {
         text: editedMsg
     }
-    axios.put(`${URL}/postes/${postId}`, body, createConfig(userToken))
+    axios.put(`${URL}/posts/${postId}`, body, createConfig(userToken))
     .then(res => {
         setIsDataBeingEvaluated(false);
         setIsEditing(false);

--- a/src/utils/PostsUtils.js
+++ b/src/utils/PostsUtils.js
@@ -2,6 +2,8 @@ import Post from "../components/Post/Post";
 
 import { publishNewPost } from "../service/service";
 import { isInputValid } from "./ValidationUtils";
+import { publishEditedPost } from "../service/service";
+
 
 function hasUserLikedThisPost(postLikes, userWhoIsLikingId) {
     return postLikes.find( ({userId}) => userId === userWhoIsLikingId )
@@ -32,10 +34,33 @@ function PrintedPosts(posts) {
     );
 }
 
+function cancelEditing(isEditing, text, setIsEditing, setEditedMsg) {
+    setIsEditing(!isEditing);
+    setEditedMsg(text);
+}
+
+function editPost(editedMsg, id, token, setIsDataBeingEvaluated, setIsEditing, cancelEditing) {
+    setIsDataBeingEvaluated(true);
+    publishEditedPost(editedMsg, id, token, setIsDataBeingEvaluated, setIsEditing, cancelEditing);
+}
+
+function analyzeRequest(e, editedMsg, id, token, setIsDataBeingEvaluated, setIsEditing, cancelEditing, isEditing, text, setEditedMsg) {
+    if(e.keyCode === 27) {
+        cancelEditing(isEditing, text, setIsEditing, setEditedMsg)
+    }
+    if(e.keyCode === 13) {
+        editPost(editedMsg, id, token, setIsDataBeingEvaluated, setIsEditing, cancelEditing)
+    }
+}
+
+
 export {
     hasUserLikedThisPost,
     OpenLinkInNewPage,
     formattedNumberOfLikes,
     CheckPublishingBoxAndSendPost,
-    PrintedPosts
+    PrintedPosts,
+    cancelEditing,
+    editPost,
+    analyzeRequest,
 }


### PR DESCRIPTION
-> Botão de edição agora abre uma caixa de texto para edição com o valor inicial da descrição atual do post;
-> A area de texto da edição é focada automaticamento ao pressionar o botão de edição;
-> Caso o usuário clique no botão novamente ou aperte a tecla "esc" as mudanças são descartadas e o post volta a seu estado inicial sem caixa de input;
-> Envia uma requisição para o servidor caso o usuário precione a tecla "Enter" com o input de edição focado;
-> O campo de texto e os botões de deletar e editar são desabilitados durante a comunicação com a API;
-> Caso a edição seja concluída com sucesso, o campode texto some e o post volta ao normal já com a descrição editada;
-> Caso ocorra um erro na edição, um alert é mostrado para o usuário informando o erro e o campo de texto de edição volta a ficar habilitado já em foco.